### PR TITLE
Release: Fixed timeout issue

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,5 +1,16 @@
 import { PrismaClient } from "@prisma/client";
 
-const prisma = new PrismaClient();
+let prisma: PrismaClient;
+
+// Production and Preview should use the same Prisma Client instance.
+if (process.env.NODE_ENV === "production" || process.env.NODE_ENV === "test") {
+  prisma = new PrismaClient();
+} else {
+  if (!global.prisma) {
+    global.prisma = new PrismaClient();
+  }
+
+  prisma = global.prisma;
+}
 
 export default prisma;

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -2,7 +2,6 @@ import { PrismaClient } from "@prisma/client";
 
 let prisma: PrismaClient;
 
-// Production and Preview should use the same Prisma Client instance.
 if (process.env.NODE_ENV === "production" || process.env.NODE_ENV === "test") {
   prisma = new PrismaClient();
 } else {

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  // Other Next.js configuration options
+  // ...
+
+  // Enable incremental static regeneration
+  // and set a 5 second revalidation time
+  revalidate: 5,
+};

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,0 @@
-module.exports = {
-  // Other Next.js configuration options
-  // ...
-
-  // Enable incremental static regeneration
-  // and set a 5 second revalidation time
-  revalidate: 5,
-};

--- a/src/components/Profile/Artist.tsx
+++ b/src/components/Profile/Artist.tsx
@@ -139,7 +139,7 @@ const Artist = ({ artist }: { artist: User }) => {
         },
       });
       globalMutate(`/users/${artist.id}`, data);
-      setUpdatedUser({ ...artist, name: data.name, bio: data.bio });
+      setUpdatedUser(data);
       setInEditMode(false);
     } catch (err) {
       console.error(err);

--- a/src/components/Profile/Artist.tsx
+++ b/src/components/Profile/Artist.tsx
@@ -359,7 +359,7 @@ const Artist = ({ artist }: { artist: User }) => {
           )}
         </StyledProfileWrapper>
       </div>
-      <div style={{ minHeight: "94vh" }}>
+      {/* <div style={{ minHeight: "94vh" }}>
         <Spacer y={1} />
 
         <CollectionList
@@ -394,7 +394,7 @@ const Artist = ({ artist }: { artist: User }) => {
           setOpen={setEditDialogOpen}
         />
       )}
-      {showAllSelected && <ArtDialog />}
+      {showAllSelected && <ArtDialog />} */}
     </main>
   );
 };

--- a/src/components/Profile/Artist.tsx
+++ b/src/components/Profile/Artist.tsx
@@ -359,7 +359,7 @@ const Artist = ({ artist }: { artist: User }) => {
           )}
         </StyledProfileWrapper>
       </div>
-      {/* <div style={{ minHeight: "94vh" }}>
+      <div style={{ minHeight: "94vh" }}>
         <Spacer y={1} />
 
         <CollectionList
@@ -394,7 +394,7 @@ const Artist = ({ artist }: { artist: User }) => {
           setOpen={setEditDialogOpen}
         />
       )}
-      {showAllSelected && <ArtDialog />} */}
+      {showAllSelected && <ArtDialog />}
     </main>
   );
 };

--- a/src/pages/artist/[artist_id]/index.tsx
+++ b/src/pages/artist/[artist_id]/index.tsx
@@ -14,7 +14,7 @@ const Artist = (props) => {
     artist.bio.slice(0, 150) + (artist.bio.length > 150 ? "..." : "");
 
   return (
-    <Layout showCrumbs>
+    <Layout showCrumbs={false}>
       <Head>
         <title>{`${artist.name} / Art Gallery App`}</title>
         <meta
@@ -22,7 +22,8 @@ const Artist = (props) => {
           content={`Artist: ${artist.name} - ${seoBio}`}
         />
       </Head>
-      <ArtistPage artist={artist} />
+      <pre>{JSON.stringify(artist, null, 2)}</pre>
+      {/* <ArtistPage artist={artist} /> */}
     </Layout>
   );
 };
@@ -43,6 +44,8 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   const artist = await prisma.user.findUnique({
     where: { id },
   });
+
+  console.log("inside getStaticProps: ", artist);
 
   return {
     props: {

--- a/src/pages/artist/[artist_id]/index.tsx
+++ b/src/pages/artist/[artist_id]/index.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import Layout from "../../../components/Layout";
-import ArtistPage from "../../../components/Profile/Artist";
-import { GetStaticPaths, GetStaticProps } from "next";
-import prisma from "../../../../lib/prisma";
 import Head from "next/head";
 import { User } from "@prisma/client";
+import { GetStaticPaths, GetStaticProps } from "next";
+import Layout from "../../../components/Layout";
+import ArtistPage from "../../../components/Profile/Artist";
+import prisma from "../../../../lib/prisma";
 
 const Artist = (props) => {
   const artist = props.data.artist as User;
@@ -22,8 +22,7 @@ const Artist = (props) => {
           content={`Artist: ${artist.name} - ${seoBio}`}
         />
       </Head>
-      <pre>{JSON.stringify(artist, null, 2)}</pre>
-      {/* <ArtistPage artist={artist} /> */}
+      <ArtistPage artist={artist} />
     </Layout>
   );
 };
@@ -44,8 +43,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   const artist = await prisma.user.findUnique({
     where: { id },
   });
-
-  console.log("inside getStaticProps: ", artist);
 
   return {
     props: {

--- a/src/pages/artist/[artist_id]/index.tsx
+++ b/src/pages/artist/[artist_id]/index.tsx
@@ -5,24 +5,29 @@ import { GetStaticPaths, GetStaticProps } from "next";
 import Layout from "../../../components/Layout";
 import ArtistPage from "../../../components/Profile/Artist";
 import prisma from "../../../../lib/prisma";
+import { useArtist } from "../../../utils/hooks/useQueryData";
+import { useRouter } from "next/router";
 
 const Artist = (props) => {
-  const artist = props.data.artist as User;
+  const ssrArtist = props.data.artist as User;
+  console.log({ serverSideRenderedArtist: ssrArtist });
+
+  const { data: artist, isLoading } = useArtist(ssrArtist.id as string);
 
   // Create a truncated version of the bio for the meta description
   const seoBio =
-    artist.bio.slice(0, 150) + (artist.bio.length > 150 ? "..." : "");
+    ssrArtist.bio.slice(0, 150) + (ssrArtist.bio.length > 150 ? "..." : "");
 
   return (
     <Layout showCrumbs={false}>
       <Head>
-        <title>{`${artist.name} / Art Gallery App`}</title>
+        <title>{`${ssrArtist.name} / Art Gallery App`}</title>
         <meta
           name="description"
-          content={`Artist: ${artist.name} - ${seoBio}`}
+          content={`Artist: ${ssrArtist.name} - ${seoBio}`}
         />
       </Head>
-      <ArtistPage artist={artist} />
+      {isLoading ? <div>Loading...</div> : <ArtistPage artist={artist} />}
     </Layout>
   );
 };

--- a/src/pages/artist/[artist_id]/index.tsx
+++ b/src/pages/artist/[artist_id]/index.tsx
@@ -50,7 +50,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         artist: JSON.parse(JSON.stringify(artist)),
       },
     },
-    revalidate: 5,
+    revalidate: 60,
   };
 };
 


### PR DESCRIPTION
The temporary cheeky workaround I've chosen is to use SSG on the artist page to retrieve the Name and Bio for SEO purposes and then for everything else use Client side rendering. 

### Original issue: 
When using SSG (ISR), the data wasn't getting invalidated therefore, when changes were made to the profile, they weren't ever reflected because of the serverless function would timeout and never fetch the updated profile data... 

I'm like 90 percent sure there's some fundamental problem with using **Prisma** with **MongoDB** inside **Vercel's** _serverless enviroment_ and it requires more than 10 seconds timeout duration. 